### PR TITLE
Fix verifying contract field typo

### DIFF
--- a/market-makers/bus/solver-relay.md
+++ b/market-makers/bus/solver-relay.md
@@ -127,7 +127,7 @@ If the user is satisfied with the offer provided by the solver, they can sign an
       * other data depending on intent type
     * `deadline` - deadline until which this intent is valid, ISO-8601 string
     * `nonce` - unique nonce for operation
-    * `veryfying_contract` - Near Intents contract address (`intents.near`)
+    * `verifying_contract` - Near Intents contract address (`intents.near`)
   * `signature` - signature of the payload
 
 </details>
@@ -146,7 +146,7 @@ If the user is satisfied with the offer provided by the solver, they can sign an
       * other data depending on intent type
     * `deadline` - deadline until which this intent is valid, ISO-8601 string
     * `nonce` - unique nonce for operation
-    * `veryfying_contract` - Near Intents contract address (`intents.near`)
+    * `verifying_contract` - Near Intents contract address (`intents.near`)
   * `signature` - signature of the payload
   * `public_key` - signer's public key
 


### PR DESCRIPTION
## Summary
- fix all `veryfying_contract` references in solver-relay docs

## Testing
- `grep -n veryfying_contract -n market-makers/bus/solver-relay.md`

------
https://chatgpt.com/codex/tasks/task_b_6888844176c8832ca588886ac8845e95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the parameter name for the Near Intents contract address, updating it to `verifying_contract` in the relevant sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->