### PR TITLE
Fix liquidity typo and update phrase

### DIFF
--- a/market-makers/README.md
+++ b/market-makers/README.md
@@ -12,7 +12,7 @@ To start market making, you are required to perform _bridging_ and _quoting_.
 
 In order to deposit and withdraw liquidity, market makers need to send funds themselves or do it via one of the distribution channels (e.g.[ https://near-intents.org](https://near-intents.org/)) .
 
-To send the liqudity, please get familiar with [Passive Deposit/Withdrawal Service](passive-deposit-withdrawal-service.md) for deposits and with specific bridge (PoA, Omni or HOT) API for withdrawals. More information on that and an SDK will be come soon.
+To send the liquidity, please get familiar with [Passive Deposit/Withdrawal Service](passive-deposit-withdrawal-service.md) for deposits and with specific bridge (PoA, Omni or HOT) API for withdrawals. More information on that and an SDK will be available soon.
 
 ### Quoting
 


### PR DESCRIPTION
## Summary
- fix liquidity typo in Market Makers guide
- state SDK availability more clearly

## Testing
- `grep -n liqudity -r market-makers`


------
https://chatgpt.com/codex/tasks/task_b_688883ebcb2c832ca8571cbd4fe32b3b