### PR TITLE
Fix minor grammar issues

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -55,7 +55,8 @@ We appreciate contributions that:
 3. **Reference issues** - mention any related GitHub issues
 4. **Keep changes focused** - one topic per PR when possible
 
-## Questions or Need Help?
+## Questions or need help?
 
 - [Join our community Telegram Support](https://t.me/near_intents)
 - [Open an issue](https://github.com/defuse-protocol/docs/issues) for discussion before making large changes
+

--- a/faqs.md
+++ b/faqs.md
@@ -6,7 +6,7 @@ description: Frequently Asked Questions
 
 ## Is there a testnet deployment?
 
-There's no testnet deployment and no plans for it. We recommend testing on NEAR mainnet with using separate dev/test NEAR accounts.&#x20;
+There is no testnet deployment and no plans for one. We recommend testing on NEAR mainnet using separate dev/test NEAR accounts.&#x20;
 
 ## Is there support for native NEAR deposits?
 

--- a/market-makers/bus/README.md
+++ b/market-makers/bus/README.md
@@ -5,7 +5,7 @@ description: >-
 
 # Message Bus
 
-Message Bus is an additional system component that optimizes price discovery process. Any frontend app may use Message Bus or launch its own instance.
+Message Bus is an additional system component that optimizes the price discovery process. Any frontend app may use Message Bus or launch its own instance.
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/fc27dde0-7a3d-428e-9776-8743aa6b43a5" alt="Message Bus" />

--- a/market-makers/bus/usage-examples.md
+++ b/market-makers/bus/usage-examples.md
@@ -26,7 +26,7 @@ params: {
 const generateNonce = async (): Promise<string> => {
     const randomArray = randomBytes(32);
     return randomArray.toString('base64');
-    if (await this.isNonceUsed(nonceString)) { //this step can be skipped but if nonce is already used quote wont be taken into account
+    if (await this.isNonceUsed(nonceString)) { // this step can be skipped, but if the nonce is already used the quote won't be taken into account
       return this.generateNonce();
     } else {
      return nonceString;

--- a/market-makers/passive-deposit-withdrawal-service.md
+++ b/market-makers/passive-deposit-withdrawal-service.md
@@ -336,7 +336,7 @@ Optional method that notifies service about your deposit.
 
 <mark style="color:orange;">**6. Estimated withdrawal fees**</mark>
 
-Convenience method that estimate amount of fees for transactions.
+Convenience method that estimates the fees for transactions.
 
 <details>
 
@@ -344,7 +344,7 @@ Convenience method that estimate amount of fees for transactions.
 
 * `chain` - The blockchain network in format {network}:{chainId}
 * `token`  - The token identifier for which to estimate withdrawal fees
-* `address` - Recepient address
+* `address` - Recipient address
 
 </details>
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -6,7 +6,7 @@ hidden: true
 # SDK
 
 {% hint style="danger" %}
-SDK is under heavy development and the API is highly unstable. Not recommended to be used, Consider 1Click SDK instead.
+SDK is under heavy development and the API is highly unstable. It is not recommended for use. Consider the 1Click SDK instead.
 {% endhint %}
 
 ### High Level Architecture

--- a/security.md
+++ b/security.md
@@ -3,4 +3,3 @@
 List of audits could be found in [Google Drive](https://drive.google.com/drive/folders/1eNHI_GKsbmMSjeCENRklvtVh8imGSUvy?usp=sharing).
 
 Please report bugs and security vulnerabilities via AuditOne [bug bounty program](https://www.auditone.io/bug-bounty/aurora).
-


### PR DESCRIPTION
## Summary
- fix typos and clarify wording in various docs
- adjust message bus instructions
- clean up newline formatting

## Testing
- `codespell -q 3`
- `markdownlint '**/*.md' | head`

------
https://chatgpt.com/codex/tasks/task_b_68888a4b78a8832ca3bc76abbe73dbe7